### PR TITLE
Feature/teleport an asset between parachains(statemint <-> parachain template node) 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7427,6 +7427,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-registry"
+version = "0.0.1"
+source = "git+https://github.com/InfraBlockchain/infra-trappist?branch=dev#78fef231752833bc068439d7168a08c9e54429f3"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+ "xcm",
+ "xcm-primitives",
+]
+
+[[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/InfraBlockchain/infra-substrate?branch=master#86932c8d7663f150e64578aef855ed5a00614659"
@@ -8586,6 +8604,7 @@ dependencies = [
 name = "parachain-template-runtime"
 version = "0.1.0"
 dependencies = [
+ "assets-common",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -8606,6 +8625,7 @@ dependencies = [
  "infrablockspace-parachain",
  "infrablockspace-runtime-common",
  "log",
+ "pallet-asset-registry",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
@@ -8619,6 +8639,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-xcm",
  "parachain-info",
+ "parachains-common",
  "parity-scale-codec",
  "scale-info",
  "smallvec",
@@ -8637,6 +8658,7 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+ "xcm-primitives",
 ]
 
 [[package]]
@@ -14589,6 +14611,17 @@ dependencies = [
  "sp-std",
  "sp-weights",
  "xcm",
+]
+
+[[package]]
+name = "xcm-primitives"
+version = "0.0.1"
+source = "git+https://github.com/InfraBlockchain/infra-trappist?branch=dev#78fef231752833bc068439d7168a08c9e54429f3"
+dependencies = [
+ "frame-support",
+ "sp-std",
+ "xcm",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/parachain-template/node/src/chain_spec.rs
+++ b/parachain-template/node/src/chain_spec.rs
@@ -192,7 +192,11 @@ fn testnet_genesis(
 				.to_vec(),
 		},
 		balances: parachain_template_runtime::BalancesConfig {
-			balances: endowed_accounts.iter().cloned().map(|k| (k, 1 << 60)).collect(),
+			balances: endowed_accounts
+				.iter()
+				.cloned()
+				.map(|k| (k, 1_000_000 * EXISTENTIAL_DEPOSIT))
+				.collect(),
 		},
 		parachain_info: parachain_template_runtime::ParachainInfoConfig { parachain_id: id },
 		collator_selection: parachain_template_runtime::CollatorSelectionConfig {
@@ -216,24 +220,18 @@ fn testnet_genesis(
 		// of this.
 		sudo: parachain_template_runtime::SudoConfig { key: Some(root_key) },
 		assets: pallet_assets::GenesisConfig {
-			assets: vec![
-				(99, get_account_id_from_seed::<sr25519::Public>("Alice"), true, 1),
-			],
-			metadata: vec![
-				(
-					99,
-					"iUNIT".to_string().as_bytes().to_vec(),
-					"iUNIT".to_string().as_bytes().to_vec(),
-					12,
-				),
-			],
-			accounts: vec![
-				(
-					99,
-					get_account_id_from_seed::<sr25519::Public>("Alice"),
-					1_000_000_000_000_000_000_000,
-				),
-			],
+			assets: vec![(
+				99,                                                   // asset_id
+				get_account_id_from_seed::<sr25519::Public>("Alice"), // owner
+				true,                                                 // is_sufficient
+				1000,                                                 // min_balance
+			)],
+			metadata: vec![(99, "iTEST".into(), "iTEST".into(), 12)],
+			accounts: vec![(
+				99,
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				1_000_000_000_000_000_000_000, // 1_000_000_000 iTEST
+			)],
 			..Default::default()
 		},
 		aura: Default::default(),

--- a/parachain-template/node/src/chain_spec.rs
+++ b/parachain-template/node/src/chain_spec.rs
@@ -227,11 +227,6 @@ fn testnet_genesis(
 				1000,                                                 // min_balance
 			)],
 			metadata: vec![(99, "iTEST".into(), "iTEST".into(), 12)],
-			// accounts: vec![(
-			// 	99,
-			// 	get_account_id_from_seed::<sr25519::Public>("Alice"),
-			// 	1_000_000_000_000_000_000_000, // 1_000_000_000 iTEST
-			// )],
 			..Default::default()
 		},
 		aura: Default::default(),

--- a/parachain-template/node/src/chain_spec.rs
+++ b/parachain-template/node/src/chain_spec.rs
@@ -227,11 +227,11 @@ fn testnet_genesis(
 				1000,                                                 // min_balance
 			)],
 			metadata: vec![(99, "iTEST".into(), "iTEST".into(), 12)],
-			accounts: vec![(
-				99,
-				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				1_000_000_000_000_000_000_000, // 1_000_000_000 iTEST
-			)],
+			// accounts: vec![(
+			// 	99,
+			// 	get_account_id_from_seed::<sr25519::Public>("Alice"),
+			// 	1_000_000_000_000_000_000_000, // 1_000_000_000 iTEST
+			// )],
 			..Default::default()
 		},
 		aura: Default::default(),

--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -23,11 +23,14 @@ log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.3.1", default-features = false, features = ["derive"] }
 smallvec = "1.10.0"
 
-
 # Substrate
 pallet-infra-asset-tx-payment = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 pallet-assets = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
+pallet-asset-registry = { package = "pallet-asset-registry", git = "https://github.com/InfraBlockchain/infra-trappist", branch = "dev", default-features = false }
+xcm-primitives = { package = "xcm-primitives", git = "https://github.com/InfraBlockchain/infra-trappist", branch = "dev", default-features = false }
 
+assets-common = { path = "../../parachains/runtimes/assets/common", default-features = false }
+parachains-common = { path = "../../parachains/common", default-features = false }
 frame-benchmarking = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, optional = true, branch = "master" }
 frame-executive = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
 frame-support = { git = "https://github.com/InfraBlockchain/infra-substrate", default-features = false, branch = "master" }
@@ -102,7 +105,8 @@ std = [
 	"pallet-collator-selection/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
-	# "pallet-template/std",
+	"pallet-asset-registry/std",
+
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -124,6 +128,8 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"assets-common/std",
+	"parachains-common/std",
 ]
 
 runtime-benchmarks = [
@@ -151,6 +157,7 @@ try-runtime = [
 	"frame-executive/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
+	"pallet-asset-registry/try-runtime",
 	"pallet-aura/try-runtime",
 	"pallet-authorship/try-runtime",
 	"pallet-balances/try-runtime",
@@ -161,4 +168,5 @@ try-runtime = [
 	"pallet-transaction-payment/try-runtime",
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
+
 ]

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -109,8 +109,9 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	// pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
+	// Let's keep the below comment to test the new feature until "PolkadotJS" is newly implemented!
+	// pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -269,30 +270,6 @@ parameter_types! {
 }
 
 type AssetId = u32;
-
-// pub type TrustBackedAssetsInstance = pallet_assets::Instance1;
-// type TrustBackedAssetsCall = pallet_assets::Call<Runtime, TrustBackedAssetsInstance>;
-
-// impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
-// 	type RuntimeEvent = RuntimeEvent;
-// 	type Balance = Balance;
-// 	type AssetId = AssetId;
-// 	type AssetIdParameter = codec::Compact<AssetId>;
-// 	type Currency = Balances;
-// 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
-// 	type ForceOrigin = EnsureRoot<AccountId>;
-// 	type AssetDeposit = ConstU128<2>;
-// 	type AssetAccountDeposit = ConstU128<2>;
-// 	type MetadataDepositBase = ConstU128<0>;
-// 	type MetadataDepositPerByte = ConstU128<0>;
-// 	type ApprovalDeposit = ConstU128<0>;
-// 	type StringLimit = ConstU32<20>;
-// 	type Freezer = ();
-// 	type Extra = ();
-// 	type CallbackHandle = ();
-// 	type WeightInfo = ();
-// 	type RemoveItemsLimit = ConstU32<1000>;
-// }
 
 impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -109,7 +109,8 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	// pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.
@@ -268,6 +269,31 @@ parameter_types! {
 }
 
 type AssetId = u32;
+
+// pub type TrustBackedAssetsInstance = pallet_assets::Instance1;
+// type TrustBackedAssetsCall = pallet_assets::Call<Runtime, TrustBackedAssetsInstance>;
+
+// impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
+// 	type RuntimeEvent = RuntimeEvent;
+// 	type Balance = Balance;
+// 	type AssetId = AssetId;
+// 	type AssetIdParameter = codec::Compact<AssetId>;
+// 	type Currency = Balances;
+// 	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId>>;
+// 	type ForceOrigin = EnsureRoot<AccountId>;
+// 	type AssetDeposit = ConstU128<2>;
+// 	type AssetAccountDeposit = ConstU128<2>;
+// 	type MetadataDepositBase = ConstU128<0>;
+// 	type MetadataDepositPerByte = ConstU128<0>;
+// 	type ApprovalDeposit = ConstU128<0>;
+// 	type StringLimit = ConstU32<20>;
+// 	type Freezer = ();
+// 	type Extra = ();
+// 	type CallbackHandle = ();
+// 	type WeightInfo = ();
+// 	type RemoveItemsLimit = ConstU32<1000>;
+// }
+
 impl pallet_assets::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Balance = Balance;
@@ -511,6 +537,13 @@ impl pallet_collator_selection::Config for Runtime {
 	type WeightInfo = ();
 }
 
+impl pallet_asset_registry::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type ReserveAssetModifierOrigin = EnsureRoot<AccountId>;
+	type Assets = Assets;
+	type WeightInfo = ();
+}
+
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub enum Runtime where
@@ -530,6 +563,7 @@ construct_runtime!(
 		TransactionPayment: pallet_transaction_payment = 11,
 		Assets: pallet_assets = 12,
 		InfraAssetTxPayment: pallet_infra_asset_tx_payment = 13,
+		AssetRegistry: pallet_asset_registry::{Pallet, Call, Storage, Event<T>} = 14,
 
 		// Collator support. The order of these 4 are important and shall not change.
 		Authorship: pallet_authorship = 20,

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -1,36 +1,27 @@
 use super::{
-	AccountId, AllPalletsWithSystem, AssetRegistry, Assets, Authorship, Balance, Balances,
-	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
-	WeightToFee, XcmpQueue,
+	AccountId, AllPalletsWithSystem, Assets, Authorship, Balance, Balances, ParachainInfo,
+	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee,
+	XcmpQueue,
 };
-use core::marker::PhantomData;
 use frame_support::{
-	log, match_types, parameter_types,
-	traits::{ConstU32, Everything, Nothing, PalletInfoAccess},
+	match_types, parameter_types,
+	traits::{ConstU32, Everything, Nothing},
 	weights::Weight,
 };
 use infrablockspace_parachain::primitives::Sibling;
 use infrablockspace_runtime_common::impls::ToAuthor;
 use pallet_xcm::XcmPassthrough;
-use parachains_common::xcm_config::{
-	AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
-};
-use sp_runtime::traits::ConvertInto;
+use parachains_common::xcm_config::{DenyReserveTransferToRelayChain, DenyThenTry};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
-	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, AsPrefixedGeneralIndex,
-	ConvertedConcreteAssetId, ConvertedConcreteId, CurrencyAdapter, EnsureXcmOrigin,
-	FixedWeightBounds, FungiblesAdapter, IsConcrete, LocalMint, NativeAsset, NoChecking,
-	NonLocalMint, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
-	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
-	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WithComputedOrigin,
+	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin,
+	FixedWeightBounds, FungiblesAdapter, IsConcrete, NativeAsset, NonLocalMint, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	UsingComponents, WithComputedOrigin,
 };
-use xcm_executor::{
-	traits::{JustTry, ShouldExecute},
-	XcmExecutor,
-};
-use xcm_primitives::AsAssetMultiLocation;
+use xcm_executor::XcmExecutor;
 
 parameter_types! {
 	// pub const RelayLocation: MultiLocation = MultiLocation::parent();
@@ -38,18 +29,12 @@ parameter_types! {
 		parents:1,
 		interior:Junctions::X1(Parachain(1000))
 	};
-	// pub const AssetLocation: MultiLocation = MultiLocation{
-	// 	parents:1,
-	// 	interior:Junctions::X1(Parachain(1000))
-	// };
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorMultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
 	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 	pub TrustBackedAssetsPalletLocation: MultiLocation =
 	MultiLocation::new(1, X2(Parachain(1000), PalletInstance(50)));
-	// pub TrustBackedAssetsPalletLocation: MultiLocation =
-	// PalletInstance(<Assets as PalletInfoAccess>::index() as u8).into();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -174,15 +159,7 @@ parameter_types! {
 }
 
 pub type AssetTransactors = (LocalAssetTransactor, FungiblesTransactor);
-
 pub type TrustedTeleporters = (xcm_builder::Case<ItestForInfraSystem>, NativeAsset);
-
-// pub type AssetFeeAsExistentialDepositMultiplierFeeCharger = AssetFeeAsExistentialDepositMultiplier<
-// 	Runtime,
-// 	WeightToFee,
-// 	pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto, TrustBackedAssetsInstance>,
-// 	TrustBackedAssetsInstance,
-// >;
 
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -1,31 +1,55 @@
 use super::{
-	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
-	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
+	AccountId, AllPalletsWithSystem, AssetRegistry, Assets, Authorship, Balance, Balances,
+	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
+	WeightToFee, XcmpQueue,
 };
 use core::marker::PhantomData;
 use frame_support::{
 	log, match_types, parameter_types,
-	traits::{ConstU32, Everything, Nothing},
+	traits::{ConstU32, Everything, Nothing, PalletInfoAccess},
 	weights::Weight,
 };
 use infrablockspace_parachain::primitives::Sibling;
 use infrablockspace_runtime_common::impls::ToAuthor;
 use pallet_xcm::XcmPassthrough;
+use parachains_common::xcm_config::{
+	AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
+};
+use sp_runtime::traits::ConvertInto;
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
-	CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, NativeAsset, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
-	UsingComponents, WithComputedOrigin,
+	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
+	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, AsPrefixedGeneralIndex,
+	ConvertedConcreteAssetId, ConvertedConcreteId, CurrencyAdapter, EnsureXcmOrigin,
+	FixedWeightBounds, FungiblesAdapter, IsConcrete, LocalMint, NativeAsset, NoChecking,
+	NonLocalMint, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents, WithComputedOrigin,
 };
-use xcm_executor::{traits::ShouldExecute, XcmExecutor};
+use xcm_executor::{
+	traits::{JustTry, ShouldExecute},
+	XcmExecutor,
+};
+use xcm_primitives::AsAssetMultiLocation;
 
 parameter_types! {
-	pub const RelayLocation: MultiLocation = MultiLocation::parent();
+	// pub const RelayLocation: MultiLocation = MultiLocation::parent();
+	pub const NativeLocation: MultiLocation = MultiLocation{
+		parents:1,
+		interior:Junctions::X1(Parachain(1000))
+	};
+	// pub const AssetLocation: MultiLocation = MultiLocation{
+	// 	parents:1,
+	// 	interior:Junctions::X1(Parachain(1000))
+	// };
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorMultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
+	pub TrustBackedAssetsPalletLocation: MultiLocation =
+	MultiLocation::new(1, X2(Parachain(1000), PalletInstance(50)));
+	// pub TrustBackedAssetsPalletLocation: MultiLocation =
+	// PalletInstance(<Assets as PalletInfoAccess>::index() as u8).into();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -45,13 +69,33 @@ pub type LocalAssetTransactor = CurrencyAdapter<
 	// Use this currency:
 	Balances,
 	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<RelayLocation>,
+	IsConcrete<NativeLocation>,
 	// Do a simple punn to convert an AccountId32 MultiLocation into a native chain account ID:
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
 	// We don't track any teleports.
 	(),
+>;
+
+pub type TrustBackedAssetsConvertedConcreteId =
+	assets_common::TrustBackedAssetsConvertedConcreteId<TrustBackedAssetsPalletLocation, Balance>;
+
+/// Means for transacting assets besides the native currency on this chain.
+pub type FungiblesTransactor = FungiblesAdapter<
+	// Use this fungibles implementation:
+	Assets,
+	// Use this currency when it is a fungible asset matching the given location or name:
+	TrustBackedAssetsConvertedConcreteId,
+	// Convert an XCM MultiLocation into a local account id:
+	LocationToAccountId,
+	// Our chain's account ID type (we can't get away without mentioning it explicitly):
+	AccountId,
+	// We only want to allow teleports of known assets. We use non-zero issuance as an indication
+	// that this asset is known.
+	NonLocalMint<parachains_common::impls::NonZeroIssuance<AccountId, Assets>>,
+	// The account to use for tracking teleports.
+	CheckingAccount,
 >;
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
@@ -80,6 +124,7 @@ parameter_types! {
 	pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub XcmAssetFeesReceiver: Option<AccountId> = Authorship::author();
 }
 
 match_types! {
@@ -87,81 +132,31 @@ match_types! {
 		MultiLocation { parents: 1, interior: Here } |
 		MultiLocation { parents: 1, interior: X1(Plurality { id: BodyId::Executive, .. }) }
 	};
-}
-
-//TODO: move DenyThenTry to polkadot's xcm module.
-/// Deny executing the xcm message if it matches any of the Deny filter regardless of anything else.
-/// If it passes the Deny, and matches one of the Allow cases then it is let through.
-pub struct DenyThenTry<Deny, Allow>(PhantomData<Deny>, PhantomData<Allow>)
-where
-	Deny: ShouldExecute,
-	Allow: ShouldExecute;
-
-impl<Deny, Allow> ShouldExecute for DenyThenTry<Deny, Allow>
-where
-	Deny: ShouldExecute,
-	Allow: ShouldExecute,
-{
-	fn should_execute<RuntimeCall>(
-		origin: &MultiLocation,
-		message: &mut [Instruction<RuntimeCall>],
-		max_weight: Weight,
-		weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		Deny::should_execute(origin, message, max_weight, weight_credit)?;
-		Allow::should_execute(origin, message, max_weight, weight_credit)
-	}
-}
-
-// See issue <https://github.com/paritytech/polkadot/issues/5233>
-pub struct DenyReserveTransferToRelayChain;
-impl ShouldExecute for DenyReserveTransferToRelayChain {
-	fn should_execute<RuntimeCall>(
-		origin: &MultiLocation,
-		message: &mut [Instruction<RuntimeCall>],
-		_max_weight: Weight,
-		_weight_credit: &mut Weight,
-	) -> Result<(), ()> {
-		if message.iter().any(|inst| {
-			matches!(
-				inst,
-				InitiateReserveWithdraw {
-					reserve: MultiLocation { parents: 1, interior: Here },
-					..
-				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-					TransferReserveAsset {
-						dest: MultiLocation { parents: 1, interior: Here },
-						..
-					}
-			)
-		}) {
-			return Err(()) // Deny
-		}
-
-		// An unexpected reserve transfer has arrived from the Relay Chain. Generally, `IsReserve`
-		// should not allow this, but we just log it here.
-		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
-			message.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
-		{
-			log::warn!(
-				target: "xcm::barriers",
-				"Unexpected ReserveAssetDeposited from the Relay Chain",
-			);
-		}
-		// Permit everything else
-		Ok(())
-	}
+	pub type ParentOrSiblings: impl Contains<MultiLocation> = {
+		MultiLocation { parents: 1, interior: Here } |
+		MultiLocation { parents: 1, interior: X1(_) }
+	};
+	pub type ParentOrParentsPlurality: impl Contains<MultiLocation> = {
+		MultiLocation { parents: 1, interior: Here } |
+		MultiLocation { parents: 1, interior: X1(Plurality { .. }) }
+	};
 }
 
 pub type Barrier = DenyThenTry<
 	DenyReserveTransferToRelayChain,
 	(
 		TakeWeightCredit,
+		// Expected responses are OK.
+		AllowKnownQueryResponses<PolkadotXcm>,
+		// Allow XCMs with some computed origins to pass through.
 		WithComputedOrigin<
 			(
+				// If the message is one that immediately attemps to pay for execution, then allow it.
 				AllowTopLevelPaidExecutionFrom<Everything>,
-				AllowExplicitUnpaidExecutionFrom<ParentOrParentsExecutivePlurality>,
-				// ^^^ Parent and its exec plurality get free execution
+				// Parent and its plurality (i.e. governance bodies) gets free execution.
+				AllowExplicitUnpaidExecutionFrom<ParentOrParentsPlurality>,
+				// // Subscriptions for version tracking are OK.
+				AllowSubscriptionsFrom<ParentOrSiblings>,
 			),
 			UniversalLocation,
 			ConstU32<8>,
@@ -169,20 +164,60 @@ pub type Barrier = DenyThenTry<
 	),
 >;
 
+parameter_types! {
+	pub const InfraSystem: MultiLocation = Parachain(1000).into_exterior(1);
+
+	pub const ItestInfraSystemLocation: MultiLocation = X3(Parachain(1000), PalletInstance(50), GeneralIndex(99)).into_exterior(1);
+	pub const ItestInfraSystemFilter: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(ItestInfraSystemLocation::get())});
+
+	pub const ItestForInfraSystem: (MultiAssetFilter, MultiLocation) = (ItestInfraSystemFilter::get(), InfraSystem::get());
+}
+
+pub type AssetTransactors = (LocalAssetTransactor, FungiblesTransactor);
+
+pub type TrustedTeleporters = (xcm_builder::Case<ItestForInfraSystem>, NativeAsset);
+
+// pub type AssetFeeAsExistentialDepositMultiplierFeeCharger = AssetFeeAsExistentialDepositMultiplier<
+// 	Runtime,
+// 	WeightToFee,
+// 	pallet_assets::BalanceToAssetBalance<Balances, Runtime, ConvertInto, TrustBackedAssetsInstance>,
+// 	TrustBackedAssetsInstance,
+// >;
+
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
 	type RuntimeCall = RuntimeCall;
 	type XcmSender = XcmRouter;
 	// How to withdraw and deposit an asset.
-	type AssetTransactor = LocalAssetTransactor;
+	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
 	type IsReserve = NativeAsset;
-	type IsTeleporter = (); // Teleporting is disabled.
+	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type Trader =
-		UsingComponents<WeightToFee, RelayLocation, AccountId, Balances, ToAuthor<Runtime>>;
+	type Trader = (
+		UsingComponents<WeightToFee, NativeLocation, AccountId, Balances, ToAuthor<Runtime>>,
+		UsingComponents<
+			WeightToFee,
+			ItestInfraSystemLocation,
+			AccountId,
+			Balances,
+			ToAuthor<Runtime>,
+		>,
+		// cumulus_primitives_utility::TakeFirstAssetTrader<
+		// 	AccountId,
+		// 	TrustBackedAssetsConvertedConcreteId,
+		// 	Assets,
+		// 	Assets,
+		// 	cumulus_primitives_utility::XcmFeesTo32ByteAccount<
+		// 		FungiblesTransactor,
+		// 		AccountId,
+		// 		XcmAssetFeesReceiver,
+		// 	>,
+		// >,
+	);
+
 	type ResponseHandler = PolkadotXcm;
 	type AssetTrap = PolkadotXcm;
 	type AssetClaims = PolkadotXcm;

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -2,10 +2,11 @@ use crate::impls::AccountIdOf;
 use core::marker::PhantomData;
 use frame_support::{
 	log,
-	traits::{fungibles::Inspect, tokens::BalanceConversion, ContainsPair},
+	traits::{fungibles::Inspect, tokens::BalanceConversion, ContainsPair, Currency},
 	weights::{Weight, WeightToFee, WeightToFeePolynomial},
 };
 use sp_runtime::traits::Get;
+use sp_std::fmt::Debug;
 use xcm::latest::prelude::*;
 use xcm_executor::traits::ShouldExecute;
 
@@ -97,6 +98,7 @@ where
 	>,
 	AccountIdOf<Runtime>:
 		From<infrablockspace_primitives::AccountId> + Into<infrablockspace_primitives::AccountId>,
+	CurrencyBalance: Debug,
 {
 	fn charge_weight_in_fungibles(
 		asset_id: <pallet_assets::Pallet<Runtime, AssetInstance> as Inspect<
@@ -107,7 +109,14 @@ where
 		<pallet_assets::Pallet<Runtime, AssetInstance> as Inspect<AccountIdOf<Runtime>>>::Balance,
 		XcmError,
 	> {
+		log::trace!(target: "xcm::charge_weight_in_fungibles",
+			"charge_weight_in_fungibles asset: asset_id: {:?}, weight: {:?}",
+			asset_id, weight);
 		let amount = WeightToFee::weight_to_fee(&weight);
+
+		log::trace!(target: "xcm::charge_weight_in_fungibles",
+			"charge_weight_in_fungibles asset: amount: {:?}", amount);
+
 		// If the amount gotten is not at least the ED, then make it be the ED of the asset
 		// This is to avoid burning assets and decreasing the supply
 		let asset_amount = BalanceConverter::to_asset_balance(amount, asset_id)

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -2,7 +2,7 @@ use crate::impls::AccountIdOf;
 use core::marker::PhantomData;
 use frame_support::{
 	log,
-	traits::{fungibles::Inspect, tokens::BalanceConversion, ContainsPair, Currency},
+	traits::{fungibles::Inspect, tokens::BalanceConversion, ContainsPair},
 	weights::{Weight, WeightToFee, WeightToFeePolynomial},
 };
 use sp_runtime::traits::Get;

--- a/parachains/runtimes/assets/infra-asset-system/Cargo.toml
+++ b/parachains/runtimes/assets/infra-asset-system/Cargo.toml
@@ -183,4 +183,3 @@ std = [
 	"parachains-common/std",
 	"assets-common/std",
 ]
-

--- a/parachains/runtimes/assets/infra-asset-system/src/lib.rs
+++ b/parachains/runtimes/assets/infra-asset-system/src/lib.rs
@@ -92,7 +92,7 @@ use pallet_infra_asset_tx_payment::{FungiblesAdapter, HandleCredit};
 pub use pallet_sudo::Call as SudoCall;
 pub use parachains_common as common;
 use parachains_common::{
-  impls::{AssetsToBlockAuthor, DealWithFees},
+	impls::{AssetsToBlockAuthor, DealWithFees},
 	opaque, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance, BlockNumber, Hash, Header,
 	Index, Signature, AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT,
 	NORMAL_DISPATCH_RATIO, SLOT_DURATION,
@@ -687,7 +687,8 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
+	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	// pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/parachains/runtimes/assets/infra-asset-system/src/lib.rs
+++ b/parachains/runtimes/assets/infra-asset-system/src/lib.rs
@@ -92,10 +92,9 @@ use pallet_infra_asset_tx_payment::{FungiblesAdapter, HandleCredit};
 pub use pallet_sudo::Call as SudoCall;
 pub use parachains_common as common;
 use parachains_common::{
-	impls::{AssetsToBlockAuthor, DealWithFees},
-	opaque, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance, BlockNumber, Hash, Header,
-	Index, Signature, AVERAGE_ON_INITIALIZE_RATIO, HOURS, MAXIMUM_BLOCK_WEIGHT,
-	NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	impls::DealWithFees, opaque, AccountId, AssetIdForTrustBackedAssets, AuraId, Balance,
+	BlockNumber, Hash, Header, Index, Signature, AVERAGE_ON_INITIALIZE_RATIO, HOURS,
+	MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use xcm_config::{
 	DotLocation, TrustBackedAssetsConvertedConcreteId, XcmConfig, XcmOriginToTransactDispatchOrigin,
@@ -687,8 +686,9 @@ pub type SignedExtra = (
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
-	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
-	// pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
+	// Let's keep the below comment to test the new feature until "PolkadotJS" is newly implemented!
+	// pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	pallet_infra_asset_tx_payment::ChargeAssetTxPayment<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic =

--- a/parachains/runtimes/assets/infra-asset-system/src/xcm_config.rs
+++ b/parachains/runtimes/assets/infra-asset-system/src/xcm_config.rs
@@ -34,8 +34,7 @@ use sp_runtime::traits::ConvertInto;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
-	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom,
-	AsPrefixedGeneralIndex, ConvertedConcreteId, CurrencyAdapter, EnsureXcmOrigin,
+	AllowSubscriptionsFrom, AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin,
 	FungiblesAdapter, IsConcrete, LocalMint, NativeAsset, ParentAsSuperuser, ParentIsPreset,
 	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
@@ -297,24 +296,22 @@ pub type AssetFeeAsExistentialDepositMultiplierFeeCharger = AssetFeeAsExistentia
 >;
 
 parameter_types! {
-	// pub const ItestInfraSystemLocation: MultiLocation = X2(PalletInstance(50), GeneralIndex(99)).into_location();
-	pub const ItestInfraSystemLocation: MultiLocation = X3(Parachain(1000), PalletInstance(50), GeneralIndex(99)).into_location();
+	pub const ItestInfraSystemLocation: MultiLocation = X2(PalletInstance(50), GeneralIndex(99)).into_location();
+	// pub const ItestInfraSystemLocation: MultiLocation = X3(Parachain(1000), PalletInstance(50), GeneralIndex(99)).into_location();
 	pub const ItestInfraSystemFilter: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(ItestInfraSystemLocation::get()) });
 
 	pub const TemplateParachain: MultiLocation = Parachain(2000).into_exterior(1);
 	pub const InfraSystem: MultiLocation = Parachain(1000).into_exterior(1);
 
-	pub const ItestTemplateParachainLocation: MultiLocation = X3(Parachain(2000), PalletInstance(12), GeneralIndex(99)).into_exterior(1);
-	pub const ItestTemplateParachainFilter: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(ItestTemplateParachainLocation::get()) });
-	pub const ItestForTemplateParachain: (MultiAssetFilter, MultiLocation) = (ItestTemplateParachainFilter::get(), TemplateParachain::get());
-	pub const ItestForInfraSystem: (MultiAssetFilter, MultiLocation) = (ItestInfraSystemFilter::get(), InfraSystem::get());
+	// pub const ItestTemplateParachainLocation: MultiLocation = X3(Parachain(2000), PalletInstance(12), GeneralIndex(99)).into_exterior(1);
+	// pub const ItestTemplateParachainFilter: MultiAssetFilter = Wild(AllOf { fun: WildFungible, id: Concrete(ItestTemplateParachainLocation::get()) });
+	pub const ItestForTemplateParachain: (MultiAssetFilter, MultiLocation) = (ItestInfraSystemFilter::get(), TemplateParachain::get());
+	// pub const ItestForInfraSystem: (MultiAssetFilter, MultiLocation) = (ItestInfraSystemFilter::get(), InfraSystem::get());
 }
 
 pub type TrustedTeleporters = (
 	xcm_builder::Case<ItestForTemplateParachain>,
-	xcm_builder::Case<ItestForInfraSystem>,
-	// xcm_builder::Case<ItestForTemplateParachain2>,
-	// xcm_builder::Case<ItestForInfraSystem2>,
+	// xcm_builder::Case<ItestForInfraSystem>,
 	NativeAsset,
 );
 

--- a/primitives/utility/src/lib.rs
+++ b/primitives/utility/src/lib.rs
@@ -185,6 +185,10 @@ impl<
 		// Convert to the same kind of multiasset, with the required fungible balance
 		let required = first.id.clone().into_multiasset(asset_balance.into());
 
+		log::trace!(target: "xcm::buy_weight******************* ",
+			"charge_weight_in_fungibles asset: local_asset_id: {:?}, weight: {:?}, asset_balance: {:?}, required: {:?}",
+			local_asset_id, weight, asset_balance, required);
+
 		// Substract payment
 		let unused = payment.checked_sub(required.clone()).map_err(|_| XcmError::TooExpensive)?;
 

--- a/zombienet/examples/bridge_hub_infra_local_network.toml
+++ b/zombienet/examples/bridge_hub_infra_local_network.toml
@@ -1,6 +1,6 @@
 [relaychain]
 default_command = "../infra-relay-chain/target/release/infrablockspace"
-
+default_args = ["-lparachain=debug", "-l=xcm=trace"]
 # chain = "rococo-local"
 chain = "rococo-local"
 
@@ -42,58 +42,34 @@ cumulus_based = true
 [[parachains.collators]]
 name = "alice"
 validator = true
-command = "./target/release/infrablockspace-parachain"
 args = ["-lparachain=debug", "-l=xcm=trace"]
+command = "./target/release/infrablockspace-parachain"
 rpc_port = 9500
 ws_port = 9501
 
+[[parachains]]
+id = 2000
+chain = "local"
+# chain = "infra-asset-system-local"
+cumulus_based = true
 
-# run bob as parachain collator
+# run alice as parachain collator
 [[parachains.collators]]
 name = "bob"
 validator = true
-command = "./target/release/infrablockspace-parachain"
 args = ["-lparachain=debug", "-l=xcm=trace"]
-rpc_port = 9600
-ws_port = 9601
+command = "./target/release/parachain-template-node"
+rpc_port = 10500
+ws_port = 10501
 
-# [[parachains]]
-# id = 1000
-# chain = "statemine-local"
-# add_to_genesis = true
-# cumulus_based = true
+[[hrmp_channels]]
+sender = 1000
+recipient = 2000
+max_capacity = 8
+max_message_size = 1048576
 
-# [parachains.collator]
-# name = "inframine"
-# command = "./target/release/parachain-template-node"
-# rpc_port = 9700
-# ws_port = 9701
-# args = ["-l=xcm=trace"]
-
-# # run charlie as parachain collator
-# [[parachains.collators]]
-# name = "charlie"
-# validator = true
-# command = "./target/release/parachain-template-node"
-# args = ["-lparachain=debug"]
-
-# # run dave as parachain collator
-# [[parachains.collators]]
-# name = "dave"
-# validator = true
-# command = "./target/release/parachain-template-node"
-# args = ["-lparachain=debug"]
-
-# # run eve as parachain collator
-# [[parachains.collators]]
-# name = "eve"
-# validator = true
-# command = "./target/release/parachain-template-node"
-# args = ["-lparachain=debug"]
-
-# # run ferdie as parachain collator
-# [[parachains.collators]]
-# name = "ferdie"
-# validator = true
-# command = "./target/release/parachain-template-node"
-# args = ["-lparachain=debug"]
+[[hrmp_channels]]
+sender = 2000
+recipient = 1000
+max_capacity = 8
+max_message_size = 1048576

--- a/zombienet/examples/bridge_hub_infra_local_network.toml
+++ b/zombienet/examples/bridge_hub_infra_local_network.toml
@@ -1,38 +1,37 @@
 [relaychain]
 default_command = "../infra-relay-chain/target/release/infrablockspace"
-default_args = ["-lparachain=debug"]
+
 # chain = "rococo-local"
 chain = "rococo-local"
 
 [[relaychain.nodes]]
 name = "alice"
 validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
+
 rpc_port = 7100
 ws_port = 7101
 
 [[relaychain.nodes]]
 name = "bob"
 validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 7200
 ws_port = 7201
 
 [[relaychain.nodes]]
 name = "charlie"
 validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 7300
 ws_port = 7301
 
 [[relaychain.nodes]]
 name = "dave"
 validator = true
+args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 7400
 ws_port = 7401
-
-[[relaychain.nodes]]
-name = "eve"
-validator = true
-rpc_port = 7500
-ws_port = 7501
 
 [[parachains]]
 id = 1000
@@ -44,7 +43,7 @@ cumulus_based = true
 name = "alice"
 validator = true
 command = "./target/release/infrablockspace-parachain"
-args = ["-lparachain=debug"]
+args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 9500
 ws_port = 9501
 
@@ -54,7 +53,7 @@ ws_port = 9501
 name = "bob"
 validator = true
 command = "./target/release/infrablockspace-parachain"
-args = ["-lparachain=debug"]
+args = ["-lparachain=debug", "-l=xcm=trace"]
 rpc_port = 9600
 ws_port = 9601
 

--- a/zombienet/examples/bridge_hub_infra_local_network.toml
+++ b/zombienet/examples/bridge_hub_infra_local_network.toml
@@ -50,7 +50,6 @@ ws_port = 9501
 [[parachains]]
 id = 2000
 chain = "local"
-# chain = "infra-asset-system-local"
 cumulus_based = true
 
 # run alice as parachain collator


### PR DESCRIPTION
### Features

Between para chains, the system token(asset_id=99) should be teleported.
So far, only Asset_id=99 can be teleported.
### Changes

- XCM config of infra-asset-system and parachain-template are modified to teleport assets.
    - Asset minting location => infra-asset-system(parachain 1000)
    - `IsTeleporter` is changed to accept teleporting asset_id = 99
    - `AssetTransactor` and `Trader` are also modified.

### Descriptions
- **Teleport from Statemine to template-node (Asset minted by statemint: pallet = 50, asset_id = 99)**
    - use this encoded data when sending a extrinsic in polkadot-js (when infra-asset-tx-payment is not applied)
0x1f0901010100411f01000101008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a4801040000020432058d01000f0080c6a47e8d030000000000
    
- **Teleport from template-node to Statemine (Asset minted by statemint: pallet = 50, asset_id = 99)**
    - use this encoded data when sending a extrinsic in polkadot-js (when infra-asset-tx-payment is not applied) 0x1f0901010100a10f010001010090b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22010400010300a10f0432058d01000f00404c948b32030000000000
  
### Referneces
- [FungibleAdapter issue](https://github.com/paritytech/polkadot/pull/6739)

### Issues
- #45 